### PR TITLE
Add issue status filter to history view

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,6 +361,7 @@
         function IssuesPage({ goPlan }){
           const [form, setForm] = useState({employeeId:'', taskId:'', message:''});
           const [files, setFiles] = useState([]);
+          const [statusFilter, setStatusFilter] = useState('all');
           const stations = Object.values(STATIONS).flat();
           useEffect(()=>{ if(!issues?.length) loadIssues(); }, []);
           const onFiles = (e)=>{ setFiles(Array.from(e.target.files||[]).slice(0,4)); };
@@ -448,14 +449,21 @@ async function submitIssue(e){
               </div>
               <div className="col-span-12 md:col-span-8">
                 <div className="card p-4">
-                  <div className="text-lg font-semibold mb-2">ประวัติปัญหา</div>
+                  <div className="mb-2 flex items-center justify-between">
+                    <div className="text-lg font-semibold">ประวัติปัญหา</div>
+                    <select className="rounded-lg border border-slate-300 px-2 py-1 text-sm" value={statusFilter} onChange={e=>setStatusFilter(e.target.value)}>
+                      <option value="all">ทั้งหมด</option>
+                      <option value="open">เปิด</option>
+                      <option value="closed">ปิดแล้ว</option>
+                    </select>
+                  </div>
                   <div className="overflow-auto">
                     <table className="min-w-full text-sm">
                       <thead className="text-left text-slate-500">
                         <tr><th className="py-2 pr-3">เวลา</th><th className="py-2 pr-3">พนักงาน</th><th className="py-2 pr-3">สแตชัน</th><th className="py-2 pr-3">ข้อความ</th><th className="py-2 pr-3">รูป</th><th className="py-2 pr-3">สถานะ</th></tr>
                       </thead>
                       <tbody>
-                        {issues.map((it,idx)=>(
+                        {issues.filter(it=>statusFilter==='all' || String(it.status||'').toLowerCase()===statusFilter).map((it,idx)=>(
                           <tr key={idx} className="border-t">
                             <td className="py-2 pr-3">{it.time||''}</td>
                             <td className="py-2 pr-3">{it.employeeName?`${it.employeeName} (${it.employeeId||''})`:(it.employeeId||'')}</td>


### PR DESCRIPTION
## Summary
- add status filter dropdown to issue history
- filter issue list by chosen status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b44eae488322912376cb604b0f9e